### PR TITLE
Make handling adb shell responses platform independent and add state audioPlaying

### DIFF
--- a/firetv.js
+++ b/firetv.js
@@ -377,22 +377,8 @@ FireTV.prototype.updateState = function (state) {
 
 
 FireTV.prototype.getPowerState = function (cb) {
-    this.shell('dumpsys power', function (ar) {
-        // var value = ar.join('\r');
-        // var RE_KEYVAL = /^\s*(\S*)=(\S)\r?$/gm;
-        // var properties = {};
-        // var match;
-        // value = value.substr(52);
-        // while (match = RE_KEYVAL.exec(value)) {
-        //     properties[match[1]] = match[2];
-        // }
-
-        var power = lines2Object(ar);
-        var on = power.Display_Power__state;
-        //var i = power.mScreenOn;
-        // power.mSystemReady
-        // power.mDisplayReady;
-        cb && cb(on === 'ON');
+    this.shell1(`dumpsys power | grep  -E \'Display Power: state=ON\' | wc -l`, function (ar) {
+        cb && cb(ar > 0);
     });
 };
 

--- a/firetv.js
+++ b/firetv.js
@@ -3,6 +3,7 @@
 var soef = require(`${__dirname}/lib/dontBeSoSoef`),
     adb = require('adbkit'),
     path = require('path'),
+    os = require('os'),
     Mdns = require('mdns-discovery');
 
 let Client;
@@ -20,7 +21,7 @@ Client.prototype.shellEx = function(id, command, cb) {
         if (err || !stream) return cb & cb(err, 0);
         adb.util.readAll(stream, function (err, output) {
             if (err || !stream) return cb && cb(err);
-            var ar = output.toString().split('\r\n');
+            var ar = output.toString().split(os.EOL);
             ar.length--;
             for (var i=ar.length-1; i > ar.length-10; i++) {
                 adapter.log.debug(ar[i]);
@@ -259,7 +260,6 @@ FireTV.prototype.startClient = function(cb) {
         // self.client.getPackages(id, function(err, packages) {
         //     if (err || !packages) return;
         // });
-
         self.client.version(function(err, version) {
             self.getAndroidVersion(function(androidVersion) {
                 self.getAPILevel(function (apiLevel) {
@@ -318,7 +318,7 @@ FireTV.prototype.handleCallback = function (err, stream, cb) {
     var self = this;
     adb.util.readAll(stream, function(err, output) {
         if (!err && output) {
-            var ar = output.toString().split('\r\n');
+            var ar = output.toString().split(os.EOL);
             ar.length--;
             // for (var i = Math.max(0, ar.length-10); i < ar.length; i++) {
             //     var line = ar[i];
@@ -353,7 +353,7 @@ FireTV.prototype.shell = function (command, cb) {
 function lines2Object(lines) {
     var o = {};
     if (!lines) return o;
-    if (typeof lines === 'string') lines = lines.split('\r\n');
+    if (typeof lines === 'string') lines = lines.split(os.EOL);
     lines.forEach(function(line) {
         line = line.trim().replace(/ |:/g, '_');
         var ar = line.split('=');


### PR DESCRIPTION
At least on my system (iobroker on a raspberry pi with Android Debug Bridge version 1.0.41 and a fire stick) results from shell commands where not handled properly, because lines are split by \r\n, but results from adb had \n. If this is an issue on all linux systems should work for all. Otherwise I could implement a safer solution that could handle either newline format on any system.

I also moved the analysis of the power state to be done on the fire stick itself, as that seems more efficient and added a state showing if audio is currently being output by the fire stick.

I did not have the resources to test on other systems